### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/scripts/extract_upload_app_details.py
+++ b/scripts/extract_upload_app_details.py
@@ -1,8 +1,14 @@
+from __future__ import print_function
 from bs4 import BeautifulSoup
 import string, os, json, time, requests
 import settings as Settings
 from cloudant import cloudant
 from cloudant.document import Document
+
+try:
+    unicode
+except NameError:  # Python 3
+    unicode = str
 
 # Grab environment and collection IDs from ingest_reviews file
 environment_id = Settings.ENVIRONMENT_ID
@@ -136,7 +142,7 @@ def upload_to_db(app_id, name, category, description, image, rating, total_revie
             doc['sentiment'] = float(query_average_app_sentiment(raw_name))
 
         # Display document for error checking
-        print app_db[app_id]
+        print(app_db[app_id])
     return
 
 # Rename to extract and upload app details.
@@ -239,4 +245,4 @@ else:
     with open(filename) as apps:
         test_app = json.loads(apps.read())
     # delete_database()
-    print extract_app_details(test_app)
+    print(extract_app_details(test_app))

--- a/scripts/ingest_reviews.py
+++ b/scripts/ingest_reviews.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #include -utf-8-
 import settings as Settings
 import grab_top_apps as Grab
@@ -43,12 +44,12 @@ def upload_review(review, collection_id):
         Settings.discovery.add_document(envmt_id, collection_id, reviewTemp)
     except:
         time.sleep(5)
-        print "adding document caused error"
+        print("adding document caused error")
     reviewTemp.close()
     return
 
 def ingest_review():
-    print "Grabbing top apps..."
+    print("Grabbing top apps...")
     top_apps_dict = Grab.grab_top_apps()
     top_apps = top_apps_dict["result"]
 
@@ -64,7 +65,7 @@ def ingest_review():
         app_name = app["title"]
         app_id = int(float(app.get('id')))
 
-        print "Extracting reviews for app %s" %app["title"]
+        print("Extracting reviews for app %s" %app["title"])
         start = time.time()
         reviews = Extract.extract_reviews(app_name, app_id)
         end = time.time()
@@ -72,19 +73,19 @@ def ingest_review():
 
         # Ingest reviews only if reviews exist.
         if total_num_reviews != 0:
-            print "extraction complete, extraction of %d number of reviews took: %d seconds" %(total_num_reviews, end-start)
+            print("extraction complete, extraction of %d number of reviews took: %d seconds" %(total_num_reviews, end-start))
             start_collection_creation = time.time()
             num_review = 0
             for review in reviews[app_name]:
                 # Create a document
-                print "Uploading review %d out of %d." %(num_review, total_num_reviews)
+                print("Uploading review %d out of %d." %(num_review, total_num_reviews))
                 upload_review(review, collection_id)
                 num_review += 1
             end_collection_creation = time.time()
             total_collection_time = end_collection_creation - start_collection_creation
             converted_time = datetime.timedelta(seconds=(total_collection_time))
-            print "Collection of %d documents for %s took: %d seconds, which is %s in hh:mm:ss form, to create." %(total_num_reviews, app_name, total_collection_time, str(converted_time))
-            print "######################### Uploaded app %d: %s ############################." %(count, app_name)
+            print("Collection of %d documents for %s took: %d seconds, which is %s in hh:mm:ss form, to create." %(total_num_reviews, app_name, total_collection_time, str(converted_time)))
+            print("######################### Uploaded app %d: %s ############################." %(count, app_name))
             count += 1
             apps_grabbed.append(app)
 
@@ -93,12 +94,12 @@ def ingest_review():
                 f.write(json.dumps(apps_grabbed, ensure_ascii=False))
 
         else:
-            print "No reviews found. Skipping app: %s" %app_name
+            print("No reviews found. Skipping app: %s" %app_name)
 
     total_end = time.time()
     total_time = total_end - total_start
-    print "This script ran for %s. Wowza." % str(datetime.timedelta(seconds=total_time))
-    print "created collection: %s with collection id = %s" %(collection_name, collection_id)
+    print("This script ran for %s. Wowza." % str(datetime.timedelta(seconds=total_time)))
+    print("created collection: %s with collection id = %s" %(collection_name, collection_id))
 
 # Call on function to begin ingesting reviews.
 ingest_review()

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # settings.py
 import os
 from os.path import join, dirname
@@ -34,20 +35,20 @@ def get_envmt_id():
 ENVIRONMENT_ID = get_envmt_id()
 
 def get_configuration_id():
-    print "getting config id"
+    print("getting config id")
     configs = discovery.list_configurations(ENVIRONMENT_ID)
     review_config = [x for x in configs['configurations'] if
                      x['name'] == 'json_config']
     return review_config[0]['configuration_id']
 
 def get_collection_id(name):
-    print "getting collection id"
+    print("getting collection id")
     config_id = get_configuration_id()
     collections = discovery.list_collections(ENVIRONMENT_ID)
     collection = [c for c in collections["collections"] if
                   c['name'] == name]
     if len(collection) == 0:
-        print "creating collection"
+        print("creating collection")
         discovery.create_collection(ENVIRONMENT_ID, name, configuration_id=config_id)
         return get_collection_id(name)
     return collection[0]['collection_id']


### PR DESCRIPTION
Fixes #1  Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.